### PR TITLE
Task/55 artifact path updating before upload

### DIFF
--- a/src/apis/models/deploy/local/minikube/deployment.yaml
+++ b/src/apis/models/deploy/local/minikube/deployment.yaml
@@ -56,5 +56,5 @@ spec:
       volumes:
         - name: nfs-server-mount
           nfs:
-            server: '10.102.146.160'
+            server: '10.106.111.120'
             path: /

--- a/src/libs/shared/src/common/application/services/artifact_service.rs
+++ b/src/libs/shared/src/common/application/services/artifact_service.rs
@@ -285,13 +285,13 @@ impl ArtifactService {
             }) as Pin<Box<dyn Future<Output = Result<(), ArtifactServiceError>> + Send + 'a>>
         };
     
-    // Closure for updating the artifact
-    let update_artifact_path = || self.artifact_repo.update_path(&artifact);
+        // Closure for updating the artifact
+        let update_artifact_path = || self.artifact_repo.update_path(&artifact);
 
-    // Persist the new Artifact to the database
-    retry_async(update_artifact_path, &Self::REPO_RETRY_POLICY).await
-        .map_err(|err| ArtifactServiceError::RepoError(err))?;
-    
+        // Persist the new Artifact to the database
+        retry_async(update_artifact_path, &Self::REPO_RETRY_POLICY).await
+            .map_err(|err| ArtifactServiceError::RepoError(err))?;
+        
         Ok((artifact.id.to_string(), stacker))
     }
 


### PR DESCRIPTION
`alexfields@tapis-ml-hub-rust:task/55-artifact-path-updating-before-upload$ curl -F "file=@$HOME/uploadtest.zip;type=application/zip" \
     http://127.0.0.1:57055/models-api/artifacts -v

*   Trying 127.0.0.1:57055...
* Connected to 127.0.0.1 (127.0.0.1) port 57055
> POST /models-api/artifacts HTTP/1.1
> Host: 127.0.0.1:57055
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Length: 437
> Content-Type: multipart/form-data; boundary=------------------------WywLzcQaV5s3avdAf9zF7A
>
* upload completely sent off: 437 bytes
< HTTP/1.1 200 OK
< Content-Length: 114
< Content-Type: application/json
< Date: Fri, 08 Aug 2025 00:57:42 GMT
<
* Connection #0 to host 127.0.0.1 left intact
{"status":200,"message":"success","result":"f047465f-931b-4f4f-82a9-9020e74c6da3","metadata":{},"version":"0.1.0"}%
alexfields@tapis-ml-hub-rust:task/55-artifact-path-updating-before-upload$ curl -F "file=@$HOME/uploadtest.zip;type=application/zip" \
     http://127.0.0.1:57055/models-api/artifacts -v

*   Trying 127.0.0.1:57055...
* Connected to 127.0.0.1 (127.0.0.1) port 57055
> POST /models-api/artifacts HTTP/1.1
> Host: 127.0.0.1:57055
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Length: 437
> Content-Type: multipart/form-data; boundary=------------------------SxnhPUgITCEJ9MFokLEeIY
>
* upload completely sent off: 437 bytes
< HTTP/1.1 200 OK
< Content-Length: 114
< Content-Type: application/json
< Date: Fri, 08 Aug 2025 00:59:45 GMT
<
* Connection #0 to host 127.0.0.1 left intact
{"status":200,"message":"success","result":"0ff342ca-fbd0-4da1-a9b8-e063dbeab43e","metadata":{},"version":"0.1.0"}%`


<img width="616" height="279" alt="Screenshot 2025-08-07 at 8 01 20 PM" src="https://github.com/user-attachments/assets/9cfcd87f-30d0-43e7-b1ad-7064a6a91fd8" />
